### PR TITLE
Updated to lmfit 0.9.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
 # Install packages
 install:
   - conda install --yes python=$TRAVIS_PYTHON_VERSION requests pip atlas numpy scipy matplotlib nose dateutil pandas statsmodels coverage lxml seaborn sympy xlrd pillow
-  - pip install https://github.com/lmfit/lmfit-py/archive/800f3e40ef8ba977005d27a5d05fd231688a5749.zip
+  - pip install lmfit===0.9.0
   - python setup.py install
 
 # Run test

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ colorama==0.3.3
 coverage==3.7.1
 docutils==0.12
 Jinja2==2.8
-lmfit===800f3e40ef8ba977005d27a5d05fd231688a5749
+lmfit===0.9.0
 lxml==3.4.2
 MarkupSafe==0.23
 matplotlib==1.4.3


### PR DESCRIPTION
See announcement on the lmfit forum: https://groups.google.com/forum/#!topic/lmfit-py/qjgrt0qFVPA.
This PR only updated `.travis.yml` and `requirements.txt` to install lmfit 0.9.0 rather than a specific commit from the github repo, as #21 already handled the required refactoring to gain the benefit of the `bic` method.
