### PR TITLE
List plate templates from the command line

### DIFF
--- a/curveball/scripts/cli.py
+++ b/curveball/scripts/cli.py
@@ -106,12 +106,19 @@ def cli(verbose, plot, prompt):
 @click.option('--plate_folder', default='plate_templates', help='plate templates default folder', type=click.Path())
 @click.option('--plate_file', default='checkerboard.csv', help='plate templates csv file')
 @click.option('-o', '--output_file', default='-', help='output csv file path', type=click.File(mode='w', lazy=True))
+@click.option('--list', is_flag=True, default=False, help='list plate templates in the default folder')
 @cli.command()
-def plate(plate_folder, plate_file, output_file):
+def plate(plate_folder, plate_file, output_file, list):
 	"""Read and output a plate from a plate file.
 	Default is to dump the plate file to the standard output.
 	TODO: plot the plate.
 	"""
+	if list:
+		files = pkg_resources.resource_listdir('plate_templates', '')
+		files = filter(lambda fn: os.path.splitext(fn)[-1].lower() == '.csv', files)
+		files = os.linesep.join(files)
+		click.echo(files)
+		return
 	plate_path = find_plate_file(plate_folder, plate_file)
 	plate = load_plate(plate_path)
 	plate.to_csv(output_file, index=False)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -101,6 +101,12 @@ class PlateTestCase(TestCase):
 		self.assertIn(__file__, result.output)
 
 
+	def test_plate_list(self):
+		result = self.runner.invoke(cli.cli, ['plate', '--list'])
+		self.assertEquals(result.exit_code, 0)
+		self.assertIn('G-RG-R.csv', result.output)
+		self.assertTrue(result.output.count('\n') > 2)
+
 class AnalysisTestCase(TestCase):
 	_multiprocess_can_split_ = True
 


### PR DESCRIPTION
Added a `--list` option to the plate command that lists the plate template csv files in the package plate templates folder.
