### PR TITLE
Build and deploy conda package from Travis-CI - closes #82

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,25 +20,31 @@ before_install:
   - chmod +x miniconda.sh
   - ./miniconda.sh -b
   - export PATH=/home/travis/miniconda/bin:$PATH
-  - conda update --yes conda
+  - conda update --yes -q conda
+  - conda config --add channels yoavram
+  - conda config --set always_yes true
+  - conda config --set anaconda_upload no
   - pip install codecov
 
 # Install packages
 install:
-  - conda install --yes python=$TRAVIS_PYTHON_VERSION requests pip atlas numpy scipy matplotlib dateutil pandas statsmodels lxml seaborn sympy xlrd
-  - pip install .[docs,tests]
+  - conda install -q python=$TRAVIS_PYTHON_VERSION pip requests conda-build jinja2 anaconda-client atlas numpy scipy matplotlib dateutil pandas statsmodels lxml seaborn sympy xlrd lmfit coverage nose pillow sphinx
+  - conda build conda-recipe
+  - conda install --use-local curveball
 
 # Run test
 script:  
   - nosetests tests --with-coverage --cover-package=curveball
 
-# Code coverage
 after_success:
+# Code coverage
   - codecov --token=$CODECOV_TOKEN
+# Deploy to Anaconda.org (conditions inside script)
+  - chmod +x ./deploy_anaconda.sh
 
-# Build docs
 before_deploy:
-  - cd docs 
+# Build docs
+  - cd docs
   - make html
   - cd ..
 
@@ -54,13 +60,22 @@ deploy:
     skip_cleanup: true
 
 # Deploy package to PyPi
-  - provider: pypi
-    user: yoavram
-    password:
-      secure: tnLc3jwANjMK+IAWEhdD2vpIzcRm5TdrK/xykh4uIovCumKTNlEUK9LrsahMxgVOkmnC4ci2phIPz1udZkHq+ICzZ8C6IlaYvhAbrKbU5FxrSbmxBdu8tilxXIMn1pmzG4yqrgdl1GQ4X/IRqYhX71O2bEUpHXlXztTLC/WSKA7onmIHFn1oCmAGq32wo2KzSRPDgkkZfDyVZshB2mTluNdXsBuImvokEU3ubNunTF7y4jSrzAwbEHgcRHyTzGDJXlnhcrWz/a+0Lttt2HmlsQpJX6GltCDnX/V8us23wj38P5e2u0D0dJ7ND3k99GY2NCkUxGXp4prikdrGdJLWdZQJ2p3Io6z9KhSQsirQPmLAry/MBbZHIvS1q8Bq4jqdCukdtXbVfkAgWOtvqsV+C5x0FtCIx0+1PTgKgvwcQwqCtGMuIhDsu65/niGGaETNxQ6/Dab1mgtT634BdPjKed4daA1evM5cQBnGt/eh62SnW5CQBpykN6w9xj4TtywTTvv8TIyr9h7geaxIT5IHWBfTWzh5IYRpj3ic41gykv8SFidpjZcxyAABOjtXtABhGVBSd8OENJEyM5y4KQhpj/Q/CdZYBoDNEf/u1UBKwhJkU1xXjWNrlqhvBZgSwqTcY4sLMdDM37FNtDEjhXtFvfb2NfBsW0IOlzwXTasdhjU=
+  # - provider: pypi
+  #   user: yoavram
+  #   password:
+  #     secure: tnLc3jwANjMK+IAWEhdD2vpIzcRm5TdrK/xykh4uIovCumKTNlEUK9LrsahMxgVOkmnC4ci2phIPz1udZkHq+ICzZ8C6IlaYvhAbrKbU5FxrSbmxBdu8tilxXIMn1pmzG4yqrgdl1GQ4X/IRqYhX71O2bEUpHXlXztTLC/WSKA7onmIHFn1oCmAGq32wo2KzSRPDgkkZfDyVZshB2mTluNdXsBuImvokEU3ubNunTF7y4jSrzAwbEHgcRHyTzGDJXlnhcrWz/a+0Lttt2HmlsQpJX6GltCDnX/V8us23wj38P5e2u0D0dJ7ND3k99GY2NCkUxGXp4prikdrGdJLWdZQJ2p3Io6z9KhSQsirQPmLAry/MBbZHIvS1q8Bq4jqdCukdtXbVfkAgWOtvqsV+C5x0FtCIx0+1PTgKgvwcQwqCtGMuIhDsu65/niGGaETNxQ6/Dab1mgtT634BdPjKed4daA1evM5cQBnGt/eh62SnW5CQBpykN6w9xj4TtywTTvv8TIyr9h7geaxIT5IHWBfTWzh5IYRpj3ic41gykv8SFidpjZcxyAABOjtXtABhGVBSd8OENJEyM5y4KQhpj/Q/CdZYBoDNEf/u1UBKwhJkU1xXjWNrlqhvBZgSwqTcY4sLMdDM37FNtDEjhXtFvfb2NfBsW0IOlzwXTasdhjU=
+  #   on:
+  #     tags: true
+  #     repo: yoavram/curveball
+  #     branch: master
+  #   server: https://testpypi.python.org/pypi
+  #   skip_cleanup: true
+
+ # Deploy to Anaconda.org
+  - provider: script
+    script: ./deploy_anaconda.sh
     on:
       tags: true
       repo: yoavram/curveball
       branch: master
-    server: https://testpypi.python.org/pypi
     skip_cleanup: true

--- a/conda-recipe/bld.bat
+++ b/conda-recipe/bld.bat
@@ -1,8 +1,2 @@
-"%PYTHON%" setup.py install
+"%PYTHON%" setup.py install --single-version-externally-managed --record=record.txt
 if errorlevel 1 exit 1
-
-:: Add more build steps here, if they are necessary.
-
-:: See
-:: http://docs.continuum.io/conda/build.html
-:: for a list of environment variables that are set during the build process.

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -1,9 +1,3 @@
 #!/bin/bash
 
-$PYTHON setup.py install
-
-# Add more build steps here, if they are necessary.
-
-# See
-# http://docs.continuum.io/conda/build.html
-# for a list of environment variables that are set during the build process.
+$PYTHON setup.py install --single-version-externally-managed --record=record.txt

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,11 +1,9 @@
 package:
   name: curveball
-  version: "0.1.10b0"
+  version: {{ environ.get('GIT_DESCRIBE_TAG', '') }}
 
 source:
-  fn: curveball-0.1.10b0.tar.gz
-  url: https://testpypi.python.org/packages/source/c/curveball/curveball-0.1.10b0.tar.gz
-  md5: f701c9d5599ee07215b76a0645f63e16
+  path: ../
 #  patches:
    # List any patch files here
    # - fix.patch
@@ -25,7 +23,7 @@ build:
 
   # If this is a new build for the same version, increment the build
   # number. If you do not include this key, it defaults to 0.
-  # number: 1
+  number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
 
 requirements:
   build:
@@ -43,7 +41,7 @@ requirements:
     - seaborn
     - statsmodels
     - sympy
-    - lmfit >=0.9.0
+    - lmfit
     - nose
 
   run:
@@ -60,7 +58,7 @@ requirements:
     - seaborn
     - statsmodels
     - sympy
-    - lmfit >=0.9.0
+    - lmfit
 
 test:
   # Python imports
@@ -74,7 +72,6 @@ test:
   commands:
     # You can put test commands to be run here.  Use this to test that the
     # entry points work.
-
     - curveball --version
 
   # You can also put a file called run_test.py in the recipe that will be run

--- a/deploy_anaconda.sh
+++ b/deploy_anaconda.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# this script uses the ANACONDA_TOKEN env var. 
+# to create a token:
+# >>> anaconda login
+# >>> anaconda auth -c -n cruveball-travis --max-age 307584000 --url https://anaconda.org/yoavram/curveball --scopes "api:write api:read"
+set -e
+
+echo "Converting conda package..."
+conda convert --platform all $HOME/miniconda/conda-bld/linux-64/curveball-*.tar.bz2 --output-dir conda-bld/
+
+echo "Deploying to Anaconda.org..."
+anaconda -t $ANACONDA_TOKEN upload conda-bld/win-32/curveball-*.tar.bz2
+anaconda -t $ANACONDA_TOKEN upload conda-bld/win-64/curveball-*.tar.bz2
+anaconda -t $ANACONDA_TOKEN upload conda-bld/linux-32/curveball-*.tar.bz2
+anaconda -t $ANACONDA_TOKEN upload conda-bld/linux-64/curveball-*.tar.bz2
+anaconda -t $ANACONDA_TOKEN upload conda-bld/osx-64/curveball-*.tar.bz2
+
+echo "Successfully deployed to Anaconda.org."
+exit 0


### PR DESCRIPTION
- auto version from git in conda-recipe
- fix conda-recipe and .travis.yml to build and install curveball using conda on travis, without pip
- deploy from travis to anaconda.org instead of pypi

This closes #82 and is inline with the docs in 2006ff3.
