### PR TITLE
Test and build for Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,17 +10,19 @@ language: python
 python:
   - 2.7
   - 3.4
+  - 3.5
 notifications:
   email: 
     - yoav@yoavram.com
 
 # Setup anaconda
 before_install:
+  - git fetch --unshallow
   - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh
   - ./miniconda.sh -b
   - export PATH=$HOME/miniconda2/bin:$PATH
-  - conda update --yes -q conda
+  - conda update --yes -q conda pip
   - conda config --add channels yoavram
   - conda config --set always_yes true
   - conda config --set anaconda_upload no
@@ -28,7 +30,7 @@ before_install:
 
 # Install packages
 install:
-  - conda install -q python=$TRAVIS_PYTHON_VERSION pip requests conda-build jinja2 anaconda-client atlas numpy scipy matplotlib dateutil pandas statsmodels lxml seaborn sympy xlrd lmfit coverage nose pillow
+  - conda install -q python=$TRAVIS_PYTHON_VERSION requests conda-build jinja2 anaconda-client atlas numpy scipy matplotlib python-dateutil pandas statsmodels lxml seaborn sympy xlrd lmfit coverage nose pillow
   - conda build -q conda-recipe
   - conda install --use-local -q curveball
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,9 +1,9 @@
 package:
   name: curveball
-  version: {{ environ.get('GIT_DESCRIBE_TAG', '') }}
+  version: {{ GIT_DESCRIBE_TAG }}
 
 source:
-  path: ../
+  git_url: ../
 #  patches:
    # List any patch files here
    # - fix.patch

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         'Natural Language :: English',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Operating System :: OS Independent',
     ],
     packages=find_packages(),


### PR DESCRIPTION
- `.travis.yml` and `setup.py`: added flag for Python 3.5
- `.travis.yml`: `dateutil` now called `python-dateutil` in conda (same as in PyPI)
- `meta.yml`: changed `source` to `git_url` to get the version from git, and `version` to not have a default value so that no version will cause an error (see conda/conda-build#357)
- update `pip` when updating `conda`
- unshallow the git repo so it could be cloned by `conda build` (see conda/conda-build#357)
- built and uploaded `lmfit` 0.9.2 for Python 3.5 to http://anaconda.org/yoavram/lmfit, not really part of the PR
